### PR TITLE
Fix status update ajax output

### DIFF
--- a/ajax/atualizar_status_pedido.php
+++ b/ajax/atualizar_status_pedido.php
@@ -1,10 +1,18 @@
 <?php
-// Garantir que nenhuma saída seja enviada antes do JSON
-ob_clean();
-header('Content-Type: application/json');
+// Desativar a exibição de erros
+error_reporting(0);
+ini_set('display_errors', 0);
 
+// Iniciar buffer de saída
+ob_start();
+
+session_start();
 // Incluir arquivo de conexão
 require_once '../database/db.php';
+
+// Limpar qualquer saída anterior
+ob_clean();
+header('Content-Type: application/json');
 
 try {
     $conn = getConnection();


### PR DESCRIPTION
## Summary
- avoid warnings when updating status by disabling error output and enabling output buffering

## Testing
- `php -l ajax/atualizar_status_pedido.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6855743cad048326b86d6f32a8677ecf