### PR TITLE
Fix login modal backdrop

### DIFF
--- a/modal/login.js
+++ b/modal/login.js
@@ -14,6 +14,9 @@ function togglePassword() {
 }
 
 $(document).ready(function () {
+  // Remove qualquer backdrop de modal que tenha ficado na página
+  $(".modal-backdrop").remove();
+  $("body").removeClass("modal-open");
   $("#loginForm").on("submit", function (e) {
     e.preventDefault();
 


### PR DESCRIPTION
## Summary
- clean up leftover `modal-backdrop` and `modal-open` classes when login page loads

## Testing
- `php -l login/index.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685587a928f88326ad14e2a761b452d1