### PR TITLE
Fix null totals in pedido_content

### DIFF
--- a/includes/pedido_content.php
+++ b/includes/pedido_content.php
@@ -109,7 +109,7 @@ $total_pronto = $stmt->get_result()->fetch_assoc()['total'];
                             $stmt->execute();
                             $total = $stmt->get_result()->fetch_assoc()['total'];
                             ?>
-                            <h3>R$ <?php echo number_format($total, 2, ',', '.'); ?></h3>
+                            <h3>R$ <?php echo number_format($total ?? 0, 2, ',', '.'); ?></h3>
                         </div>
                         <i class="fas fa-shopping-cart fa-2x opacity-50"></i>
                     </div>


### PR DESCRIPTION
## Summary
- handle null totals when formatting total de vendas

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b887466c8326a7ca2478281defe9