### PR TITLE
Fix str_replace deprecation

### DIFF
--- a/imprimir_pedido.php
+++ b/imprimir_pedido.php
@@ -207,9 +207,9 @@ if (!$data_pedido) {
 
         <!-- Totais -->
         <div class="total">
-            Sub-total: R$ <?php echo number_format(floatval(str_replace(['R$', ' '], '', $pedido['sub_total'])), 2, ',', '.'); ?><br>
-            Taxa de entrega: R$ <?php echo number_format(floatval(str_replace(['R$', ' '], '', $pedido['taxa_entrega'])), 2, ',', '.'); ?><br>
-            <strong>TOTAL: R$ <?php echo number_format(floatval(str_replace(['R$', ' '], '', $pedido['total'])), 2, ',', '.'); ?></strong><br>
+            Sub-total: R$ <?php echo number_format(floatval(str_replace(['R$', ' '], '', $pedido['sub_total'] ?? '')), 2, ',', '.'); ?><br>
+            Taxa de entrega: R$ <?php echo number_format(floatval(str_replace(['R$', ' '], '', $pedido['taxa_entrega'] ?? '')), 2, ',', '.'); ?><br>
+            <strong>TOTAL: R$ <?php echo number_format(floatval(str_replace(['R$', ' '], '', $pedido['total'] ?? '')), 2, ',', '.'); ?></strong><br>
             Forma de pagamento: <?php echo $pedido['pagamento']; ?>
         </div>
 


### PR DESCRIPTION
## Summary
- avoid passing null values to `str_replace` by providing defaults in `imprimir_pedido.php`

## Testing
- `php -l imprimir_pedido.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855bbf9e0b0832682bbc8a77447a473