### PR TITLE
Allow reselecting deliverers

### DIFF
--- a/includes/movimentacao_content.php
+++ b/includes/movimentacao_content.php
@@ -208,9 +208,7 @@ $entregas_finalizadas = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
                                     <select class="form-select form-select-sm" onchange="atribuirEntregador(<?php echo $entrega['id']; ?>, this.value)">
                                         <option value="">Selecionar...</option>
                                         <?php foreach ($entregadores as $entregador): ?>
-                                            <?php if ($entregador['status'] == 'Ativo'): ?>
-                                                <option value="<?php echo $entregador['id']; ?>"><?php echo $entregador['nome']; ?></option>
-                                            <?php endif; ?>
+                                            <option value="<?php echo $entregador['id']; ?>"><?php echo $entregador['nome']; ?></option>
                                         <?php endforeach; ?>
                                     </select>
                                 <?php endif; ?>


### PR DESCRIPTION
## Summary
- allow selecting drivers that are already out for delivery

## Testing
- `php -l includes/movimentacao_content.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6855c0378e508326813a35c78ab41a77