### PR TITLE
Fix missing user_tokens table error

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ php -S localhost:8000
 
 3. Open `http://localhost:8000/` in your browser and log in using your user credentials.
 
+On the first login the application automatically creates the `user_tokens` table
+used to store authentication tokens. Ensure your database user has permission to
+create tables.
+
 ## Authenticating with a Bearer Token
 
 Most API endpoints expect a JWT token in the `Authorization` header. To obtain

--- a/login/index.php
+++ b/login/index.php
@@ -26,10 +26,24 @@ function generateJwt(int $userId, string $username, string $secret): string {
     return "$header.$payload.$signature";
 }
 
+function ensureUserTokensTableExists(mysqli $conn): void {
+    $sql = "CREATE TABLE IF NOT EXISTS user_tokens (
+        user_id INT(11) NOT NULL,
+        token VARCHAR(255) NOT NULL,
+        expires_at DATETIME NOT NULL,
+        PRIMARY KEY (user_id),
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
+    $conn->query($sql);
+}
+
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     header('Content-Type: application/json');
     $username = $_POST['username'];
     $password = $_POST['password'];
+
+    // Garantir que a tabela de tokens exista para evitar erros de login
+    ensureUserTokensTableExists($conn);
 
    
 


### PR DESCRIPTION
## Summary
- auto create `user_tokens` table in `login/index.php`
- document automatic table creation in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68560a69d8ac8326bf3e55f1d9047307